### PR TITLE
Account for different handling of symbol keys in Rails 4.0

### DIFF
--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
               tags: [
                 {"attributes"=>{"id"=>1, "name"=>"#hash_tag"}}
               ]
-            }, adapter.serializable_hash[:post_with_tags])
+            }.to_json, adapter.serializable_hash[:post_with_tags].to_json)
           end
         end
       end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -71,7 +71,7 @@ module ActiveModel
         PostWithTagsSerializer.new(@post).each_association do |name, serializer, options|
           assert_equal name, :tags
           assert_equal serializer, nil
-          assert_equal [{ attributes: { name: "#hashtagged" }}].as_json, options[:virtual_value]
+          assert_equal [{ attributes: { name: "#hashtagged" }}].to_json, options[:virtual_value].to_json
         end
       end
 


### PR DESCRIPTION
Comparing as a JSON string vs. as the Hash that is convert to JSON
works around the different Hash representations.

This likely has to do with the introduction of
config.action_dispatch.perform_deep_munge in Rails 4.1
See Rails issue 13420

``` plain
  1) Failure:
  ActiveModel::Serializer::Adapter::Json::HasManyTestTest#test_has_many_with_no_serializer
  [active_model_serializers/test/adapter/json/has_many_test.rb:36]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -{:id=>42, :tags=>[{"attributes"=>{"id"=>1, "name"=>"#hash_tag"}}]}
  +{:id=>42, :tags=>[{"attributes"=>{:id=>1, :name=>"#hash_tag"}}]}

  2) Failure:
  ActiveModel::Serializer::AssociationsTest#test_has_many_with_no_serializer
  [active_model_serializers/test/serializers/associations_test.rb:74]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -[{"attributes"=>{"name"=>"#hashtagged"}}]
  +[{"attributes"=>{:name=>"#hashtagged"}}]
```
