### PR TITLE
Fix Gemfile for jruby.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gemspec
 
 group :development do
   gem "minitest"
-  gem "sqlite3"
+  gem "sqlite3", platform: :ruby
+  gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 end
 
 version = ENV["RAILS_VERSION"] || "4.2"


### PR DESCRIPTION
The dev dependency on `sqlite3` makes the tests fail for jruby which requires a specific adapter (`activerecord-jdbcsqlite3-adapter`).
