### PR TITLE
Revert Serialization renaming.

### DIFF
--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module ActionController
-  module Serializer
+  module Serialization
     class AdapterSelectorTest < ActionController::TestCase
       class AdapterSelectorTestController < ActionController::Base
         def render_using_default_adapter

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module ActionController
-  module Serializer
+  module Serialization
     class ExplicitSerializerTest < ActionController::TestCase
       class ExplicitSerializerTestController < ActionController::Base
         def render_using_explicit_serializer
@@ -122,7 +122,7 @@ module ActionController
               id: 42,
               lat: "-23.550520",
               lng: "-46.633309",
-              place: "Nowhere" # is a virtual attribute on LocationSerializer 
+              place: "Nowhere" # is a virtual attribute on LocationSerializer
             }
           ]
         }

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -31,7 +31,7 @@ class DefaultScopeNameTest < ActionController::TestCase
   end
 end
 
-class SerializerScopeNameTest < ActionController::TestCase
+class SerializationScopeNameTest < ActionController::TestCase
   class AdminUserSerializer < ActiveModel::Serializer
     attributes :admin?
     def admin?

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -2,10 +2,10 @@
 require 'test_helper'
 
 module ActionController
-  module Serializer
+  module Serialization
     class ImplicitSerializerTest < ActionController::TestCase
       include ActiveSupport::Testing::Stream
-      class ImplicitSerializerTestController < ActionController::Base
+      class ImplicitSerializationTestController < ActionController::Base
         def render_using_implicit_serializer
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile
@@ -154,7 +154,7 @@ module ActionController
         end
       end
 
-      tests ImplicitSerializerTestController
+      tests ImplicitSerializationTestController
 
       # We just have Null for now, this will change
       def test_render_using_implicit_serializer
@@ -400,7 +400,7 @@ module ActionController
       end
 
       def test_warn_overridding_use_adapter_as_falsy_on_controller_instance
-        controller = Class.new(ImplicitSerializerTestController) {
+        controller = Class.new(ImplicitSerializationTestController) {
           def use_adapter?
             false
           end
@@ -411,7 +411,7 @@ module ActionController
       end
 
       def test_dont_warn_overridding_use_adapter_as_truthy_on_controller_instance
-        controller = Class.new(ImplicitSerializerTestController) {
+        controller = Class.new(ImplicitSerializationTestController) {
           def use_adapter?
             true
           end


### PR DESCRIPTION
I believe these were renamed while getting rid of the "Serializer -> Serialization" renaming.
